### PR TITLE
FixStaticNamespace

### DIFF
--- a/src/code/httpConstants/httpConstants.hpp
+++ b/src/code/httpConstants/httpConstants.hpp
@@ -6,35 +6,35 @@
 
 namespace httpConstants
 {
-	static const std::string CARRIAGE_RETURN("\r");
-	static const std::string NEW_LINE("\n");
-	static const std::string FIELD_BREAK("\r\n");
-	static const std::string HEADER_BREAK("\r\n\r\n");
-	static const std::string HTML_SUFFIX(".html");
-	static const std::string TXT_SUFFIX(".txt");
-	static const std::string HTTP_VERSION("HTTP/1.1 ");
-	static const std::string SERVER_FIELD_KEY("Server: ");
-	static const std::string SERVER_FIELD_VALUE("webserv");
-	static const std::string DATE_FIELD_KEY("Date: ");
-	static const std::string CONTENT_TYPE_FIELD_KEY("Content-Type: ");
-	static const std::string CONTENT_LENGHT_FIELD_KEY("Content-Length: ");
-	static const std::string CONNECTION_FIELD_KEY("Connection: ");
-	static const std::string ALLOW_HEADER("Allow: ");
-	static const std::string CONNECTION_ALIVE("keep-alive");
-	static const std::string CONNECTION_CLOSE("close");
-	static const std::string SERVER_NAME("SERVER_NAME");
-	static const std::string SERVER_PORT("SERVER_PORT");
-	static const std::string SERVER_PROTOCOL("SERVER_PROTOCOL");
-	static const std::string QUERY_STRING("QUERY_STRING");
-	static const std::string SCRIPT_FILENAME("SCRIPT_FILENAME");
-	static const std::string REQUEST_METHOD("REQUEST_METHOD");
-	static const std::string CONTENT_TYPE("CONTENT_TYPE");
-	static const std::string CONTENT_LENGTH("CONTENT_LENGTH");
-	static const std::string UPLOAD_DIR("UPLOAD_DIR");
-	static const std::string PREVIOUS_DIR("/..");
-	static const std::string ACTUAL_DIR("/.");
-	static const std::string SEPARATOR(":");
-	static const std::string SPACE(" ");
+	const std::string CARRIAGE_RETURN("\r");
+	const std::string NEW_LINE("\n");
+	const std::string FIELD_BREAK("\r\n");
+	const std::string HEADER_BREAK("\r\n\r\n");
+	const std::string HTML_SUFFIX(".html");
+	const std::string TXT_SUFFIX(".txt");
+	const std::string HTTP_VERSION("HTTP/1.1 ");
+	const std::string SERVER_FIELD_KEY("Server: ");
+	const std::string SERVER_FIELD_VALUE("webserv");
+	const std::string DATE_FIELD_KEY("Date: ");
+	const std::string CONTENT_TYPE_FIELD_KEY("Content-Type: ");
+	const std::string CONTENT_LENGHT_FIELD_KEY("Content-Length: ");
+	const std::string CONNECTION_FIELD_KEY("Connection: ");
+	const std::string ALLOW_HEADER("Allow: ");
+	const std::string CONNECTION_ALIVE("keep-alive");
+	const std::string CONNECTION_CLOSE("close");
+	const std::string SERVER_NAME("SERVER_NAME");
+	const std::string SERVER_PORT("SERVER_PORT");
+	const std::string SERVER_PROTOCOL("SERVER_PROTOCOL");
+	const std::string QUERY_STRING("QUERY_STRING");
+	const std::string SCRIPT_FILENAME("SCRIPT_FILENAME");
+	const std::string REQUEST_METHOD("REQUEST_METHOD");
+	const std::string CONTENT_TYPE("CONTENT_TYPE");
+	const std::string CONTENT_LENGTH("CONTENT_LENGTH");
+	const std::string UPLOAD_DIR("UPLOAD_DIR");
+	const std::string PREVIOUS_DIR("/..");
+	const std::string ACTUAL_DIR("/.");
+	const std::string SEPARATOR(":");
+	const std::string SPACE(" ");
 } // namespace httpConstants
 
 #endif


### PR DESCRIPTION
my bad, static should not be used like this in .hpp file.
when we write it in the .hpp file it means that **every** file have its own static var haha
without the static we have a global var for **all** files