### PR TITLE
DupReqHeadersFix

### DIFF
--- a/src/class/BasicHTTPRequest/BasicHTTPRequest.cpp
+++ b/src/class/BasicHTTPRequest/BasicHTTPRequest.cpp
@@ -98,6 +98,41 @@ std::ostream &operator<<(std::ostream &o, BasicHTTPRequest const &i)
 ** --------------------------------- METHODS ----------------------------------
 */
 
+std::string BasicHTTPRequest::toString(void) const
+{
+	std::string type = "UNKNOWN";
+	std::string http_version = "UNKNOWN";
+
+	if (this->getHTTPVersion() == BasicHTTPRequest::HTTP_0_9)
+		http_version = "HTTP/0.9";
+	else if (this->getHTTPVersion() == BasicHTTPRequest::HTTP_1_0)
+		http_version = "HTTP/1.0";
+	else if (this->getHTTPVersion() == BasicHTTPRequest::HTTP_1_1)
+		http_version = "HTTP/1.1";
+	else if (this->getHTTPVersion() == BasicHTTPRequest::HTTP_2_0)
+		http_version = "HTTP/2.0";
+	else if (this->getHTTPVersion() == BasicHTTPRequest::HTTP_3)
+		http_version = "HTTP/3";
+
+	if (this->getType() == BasicHTTPRequest::GET)
+		type = "GET";
+	else if (this->getType() == BasicHTTPRequest::POST)
+		type = "POST";
+	else if (this->getType() == BasicHTTPRequest::DELETE)
+		type = "DELETE";
+
+	std::string ret;
+
+	ret += type + httpConstants::SPACE + this->getPath();
+
+	if (!this->getQuery().empty())
+		ret += httpConstants::SPACE + this->getQuery();
+	ret += httpConstants::SPACE + http_version + httpConstants::FIELD_BREAK +
+		   converter::headersToString(this->getHeaders()) + this->getBody();
+
+	return ret;
+}
+
 BasicHTTPRequest::Type BasicHTTPRequest::_parseType(const std::string &raw_request)
 {
 	if (raw_request.find("GET") == 0)
@@ -187,7 +222,7 @@ std::map<std::string, std::string> BasicHTTPRequest::_parseHeaders(const std::st
 		if (colon_pos > end)
 			throw BasicHTTPRequest::InvalidRequestException("Bad header: missing colon");
 
-		std::string key = raw_request.substr(start, colon_pos - start);
+		std::string key = converter::toNginxStyle(raw_request.substr(start, colon_pos - start));
 
 		colon_pos += 2;
 		std::string value = raw_request.substr(colon_pos, end - colon_pos);

--- a/src/class/BasicHTTPRequest/BasicHTTPRequest.hpp
+++ b/src/class/BasicHTTPRequest/BasicHTTPRequest.hpp
@@ -61,6 +61,7 @@ class BasicHTTPRequest
 	HTTPVersion getHTTPVersion(void) const;
 	const std::map<std::string, std::string> &getHeaders(void) const;
 	const std::string &getBody(void) const;
+	std::string toString(void) const;
 
   private:
 	const std::string _raw;

--- a/src/class/BasicHTTPRequest/BasicHTTPRequest.hpp
+++ b/src/class/BasicHTTPRequest/BasicHTTPRequest.hpp
@@ -78,6 +78,7 @@ class BasicHTTPRequest
 	static std::string _parseQuery(const std::string &raw_request);
 	static HTTPVersion _parseHTTPVersion(const std::string &raw_request);
 	static std::map<std::string, std::string> _parseHeaders(const std::string &raw_request);
+	static bool _isKeyRestricted(const std::string &key);
 };
 
 std::ostream &operator<<(std::ostream &o, const BasicHTTPRequest &i);

--- a/src/class/BasicHTTPRequest/BasicHTTPRequest.test.cpp
+++ b/src/class/BasicHTTPRequest/BasicHTTPRequest.test.cpp
@@ -106,3 +106,17 @@ TEST(BasicHTTPRequest, setBody)
 	obj.setBody();
 	EXPECT_STREQ("body", obj.getBody().c_str());
 }
+
+TEST(BasicHTTPRequest, ExceptionDupHeaders)
+{
+	EXPECT_THROW(BasicHTTPRequest obj("POST / HTTP/1.1\r\nContent-Length: 4\r\nContent-Length: 4\r\n\r\nbody"),
+				 BasicHTTPRequest::InvalidRequestException);
+}
+
+TEST(BasicHTTPRequest, AppendDupHeaders)
+{
+	BasicHTTPRequest obj("POST / HTTP/1.1\r\nasd: 4\r\nasd: 4\r\n\r\nbody");
+
+	std::map<std::string, std::string> h = obj.getHeaders();
+	EXPECT_STREQ("4, 4", h["asd"].c_str());
+}

--- a/src/class/BasicHTTPRequest/BasicHTTPRequest.test.cpp
+++ b/src/class/BasicHTTPRequest/BasicHTTPRequest.test.cpp
@@ -24,68 +24,29 @@ TEST(BasicHTTPRequest, Canonical)
 
 TEST(BasicHTTPRequest, Accessor)
 {
-	BasicHTTPRequest obj(
-		"GET /over/there?name=ferret HTTP/1.1\r\nHost: localhost:8081\r\nConnection: keep-alive\r\nsec-ch-ua: "
-		"\"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"114\", \"Opera\";v=\"100\"\r\nsec-ch-ua-mobile: "
-		"?0\r\nsec-ch-ua-platform: \"Windows\"\r\nDNT: 1\r\nUpgrade-Insecure-Requests: 1\r\nUser-Agent: Mozilla/5.0 "
-		"(Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 "
-		"OPR/100.0.0.0\r\nAccept: "
-		"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/"
-		"signed-exchange;v=b3;q=0.7\r\nSec-Fetch-Site: none\r\nSec-Fetch-Mode: navigate\r\nSec-Fetch-User: "
-		"?1\r\nSec-Fetch-Dest: document\r\nAccept-Encoding: gzip, deflate, br\r\nAccept-Language: en-US,en;q=0.9\r\n");
+	BasicHTTPRequest obj("POST /over/there?name=ferret HTTP/1.1\r\nHost: localhost:8081\r\nConnection: "
+						 "keep-alive\r\nContent-Length: 10\r\n\r\nabcdefghij");
 
-	EXPECT_EQ(BasicHTTPRequest::GET, obj.getType());
+	obj.setBody();
+	EXPECT_EQ(BasicHTTPRequest::POST, obj.getType());
 	EXPECT_EQ("/over/there", obj.getPath());
 	EXPECT_EQ("?name=ferret", obj.getQuery());
 	EXPECT_EQ(BasicHTTPRequest::HTTP_1_1, obj.getHTTPVersion());
 
-	EXPECT_EQ(15, obj.getHeaders().size());
-	EXPECT_EQ("localhost:8081", obj.getHeaders().at("Host"));
-	EXPECT_EQ("keep-alive", obj.getHeaders().at("Connection"));
-	EXPECT_EQ("\"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"114\", \"Opera\";v=\"100\"", obj.getHeaders().at("sec-ch-ua"));
-	EXPECT_EQ("?0", obj.getHeaders().at("sec-ch-ua-mobile"));
-	EXPECT_EQ("\"Windows\"", obj.getHeaders().at("sec-ch-ua-platform"));
-	EXPECT_EQ("1", obj.getHeaders().at("DNT"));
-	EXPECT_EQ("1", obj.getHeaders().at("Upgrade-Insecure-Requests"));
-	EXPECT_EQ(obj.getHeaders().at("User-Agent"),
-			  "Mozilla/5.0 "
-			  "(Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 "
-			  "OPR/100.0.0.0");
-	EXPECT_EQ(obj.getHeaders().at("Accept"),
-			  "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,"
-			  "application/"
-			  "signed-exchange;v=b3;q=0.7");
-	EXPECT_EQ("none", obj.getHeaders().at("Sec-Fetch-Site"));
-	EXPECT_EQ("navigate", obj.getHeaders().at("Sec-Fetch-Mode"));
-	EXPECT_EQ("?1", obj.getHeaders().at("Sec-Fetch-User"));
-	EXPECT_EQ("document", obj.getHeaders().at("Sec-Fetch-Dest"));
-	EXPECT_EQ("gzip, deflate, br", obj.getHeaders().at("Accept-Encoding"));
-	EXPECT_EQ("en-US,en;q=0.9", obj.getHeaders().at("Accept-Language"));
+	EXPECT_EQ("localhost:8081", obj.getHeaders().at(httpConstants::headers::HOST));
+	EXPECT_EQ("keep-alive", obj.getHeaders().at(httpConstants::headers::CONNECTION));
+	EXPECT_EQ("10", obj.getHeaders().at(httpConstants::headers::CONTENT_LENGTH));
+	EXPECT_EQ("abcdefghij", obj.getBody());
 }
 
 TEST(BasicHTTPRequest, Print)
 {
-	static const char *res =
-		"{\"_type\": \"GET\",\"_path\": \"/over/there\",\"_query\": \"?name=ferret\",\"_http_version\": "
-		"\"HTTP/1.1\",\"_headers\": {\"Accept\": "
-		"\"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/"
-		"*;q=0.8,application/signed-exchange;v=b3;q=0.7\", \"Accept-Encoding\": \"gzip, deflate, br\", "
-		"\"Accept-Language\": \"en-US,en;q=0.9\", \"Connection\": \"keep-alive\", \"DNT\": \"1\", \"Host\": "
-		"\"localhost:8081\", \"Sec-Fetch-Dest\": \"document\", \"Sec-Fetch-Mode\": \"navigate\", \"Sec-Fetch-Site\": "
-		"\"none\", \"Sec-Fetch-User\": \"?1\", \"Upgrade-Insecure-Requests\": \"1\", \"User-Agent\": \"Mozilla/5.0 "
-		"(Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 "
-		"OPR/100.0.0.0\", \"sec-ch-ua\": \"\\\"Not.A/Brand\\\";v=\\\"8\\\", \\\"Chromium\\\";v=\\\"114\\\", "
-		"\\\"Opera\\\";v=\\\"100\\\"\", \"sec-ch-ua-mobile\": \"?0\", \"sec-ch-ua-platform\": \"\\\"Windows\\\"\"}}";
+	static const char *res = "{\"_type\": \"GET\",\"_path\": \"/over/there\",\"_query\": "
+							 "\"?name=ferret\",\"_http_version\": \"HTTP/1.1\",\"_headers\": {\"Connection\": "
+							 "\"keep-alive\", \"Host\": \"localhost:8081\", \"Sec-Ch-Ua\": \"\"}}";
 
-	BasicHTTPRequest obj(
-		"GET /over/there?name=ferret HTTP/1.1\r\nHost: localhost:8081\r\nConnection: keep-alive\r\nsec-ch-ua: "
-		"\"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"114\", \"Opera\";v=\"100\"\r\nsec-ch-ua-mobile: "
-		"?0\r\nsec-ch-ua-platform: \"Windows\"\r\nDNT: 1\r\nUpgrade-Insecure-Requests: 1\r\nUser-Agent: Mozilla/5.0 "
-		"(Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 "
-		"OPR/100.0.0.0\r\nAccept: "
-		"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/"
-		"signed-exchange;v=b3;q=0.7\r\nSec-Fetch-Site: none\r\nSec-Fetch-Mode: navigate\r\nSec-Fetch-User: "
-		"?1\r\nSec-Fetch-Dest: document\r\nAccept-Encoding: gzip, deflate, br\r\nAccept-Language: en-US,en;q=0.9\r\n");
+	BasicHTTPRequest obj("GET /over/there?name=ferret HTTP/1.1\r\nHost: localhost:8081\r\nConnection: "
+						 "keep-alive\r\nsec-ch-ua: \r\n\r\n");
 
 	std::stringstream ss;
 	ss << obj;
@@ -118,5 +79,13 @@ TEST(BasicHTTPRequest, AppendDupHeaders)
 	BasicHTTPRequest obj("POST / HTTP/1.1\r\nasd: 4\r\nasd: 4\r\n\r\nbody");
 
 	std::map<std::string, std::string> h = obj.getHeaders();
-	EXPECT_STREQ("4, 4", h["asd"].c_str());
+	EXPECT_STREQ("4, 4", h["Asd"].c_str());
+}
+
+TEST(BasicHTTPRequest, toString)
+{
+	BasicHTTPRequest obj("POST / HTTP/1.1\r\ncontenT-length: 4\r\n\r\nbody");
+
+	obj.setBody();
+	EXPECT_STREQ("POST / HTTP/1.1\r\nContent-Length: 4\r\n\r\nbody", obj.toString().c_str());
 }

--- a/src/code/converter/converter.cpp
+++ b/src/code/converter/converter.cpp
@@ -123,3 +123,46 @@ std::string converter::escapeString(const std::string &input)
 	}
 	return escapedString;
 }
+
+std::string converter::toNginxStyle(const std::string &input)
+{
+	std::string result;
+	char c = 0;
+	int i = 0;
+	bool capitalizeNext = true;
+
+	while (input[i])
+	{
+		c = input[i];
+		if (std::isalpha(c))
+		{
+			if (capitalizeNext)
+			{
+				result += static_cast<char>(std::toupper(c));
+				capitalizeNext = false;
+			}
+			else
+				result += static_cast<char>(std::tolower(c));
+		}
+		else if (c == ' ' || c == '-')
+		{
+			capitalizeNext = true;
+			result += '-';
+		}
+		else
+			result += c;
+		++i;
+	}
+	return result;
+}
+
+std::string converter::headersToString(std::map<std::string, std::string> map)
+{
+	std::string result;
+
+	for (std::map<std::string, std::string>::iterator it = map.begin(); it != map.end(); ++it)
+	{
+		result += it->first + ": " + it->second + httpConstants::FIELD_BREAK;
+	}
+	return result + httpConstants::FIELD_BREAK;
+}

--- a/src/code/converter/converter.hpp
+++ b/src/code/converter/converter.hpp
@@ -5,8 +5,11 @@
 #include <cerrno>
 #include <cstdlib>
 #include <limits>
+#include <map>
 #include <sstream>
 #include <string>
+
+#include <httpConstants/httpConstants.hpp>
 
 namespace converter
 {
@@ -24,6 +27,8 @@ namespace converter
 	}
 
 	std::string escapeString(const std::string &input);
+	std::string toNginxStyle(const std::string &input);
+	std::string headersToString(std::map<std::string, std::string> map);
 
 } // namespace converter
 

--- a/src/code/httpConstants/httpConstants.hpp
+++ b/src/code/httpConstants/httpConstants.hpp
@@ -38,8 +38,10 @@ namespace httpConstants
 
 	namespace headers
 	{
-		const std::string TRANSFER_ENCODING("Transfer-Encoding");
+		const std::string DATE("Date");
 		const std::string CONTENT_LENGTH("Content-Length");
+		const std::string HOST("Host");
+		const std::string TRANSFER_ENCODING("Transfer-Encoding");
 		const std::string CHUNKED("chunked");
 	} // namespace headers
 } // namespace httpConstants

--- a/src/code/httpConstants/httpConstants.hpp
+++ b/src/code/httpConstants/httpConstants.hpp
@@ -39,6 +39,7 @@ namespace httpConstants
 	namespace headers
 	{
 		const std::string DATE("Date");
+		const std::string CONNECTION("Connection");
 		const std::string CONTENT_LENGTH("Content-Length");
 		const std::string HOST("Host");
 		const std::string TRANSFER_ENCODING("Transfer-Encoding");


### PR DESCRIPTION
check out toNginxStyle and toString
i found out that header are **not** case sensative so -> a-a == a-A == A-a
now locally all headers will fllow to nginx's case -> content-length -> Contant-Length
so i need to convert them when parsing the req so the raw req is now invalid (it is also invalide since i combain dup headers to a list)

anyway, we should start using req.toString()
